### PR TITLE
add unfocused window background color variable

### DIFF
--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -34,6 +34,7 @@ whiskers:
     --newtab-background-color: #{{ base.hex }} !important;
     --zen-themed-toolbar-bg: #{{ mantle.hex }} !important;
     --zen-main-browser-background: #{{ mantle.hex }} !important;
+    --toolbox-bgcolor-inactive: #{{ mantle.hex }} !important;
   }
 
   #permissions-granted-icon{


### PR DESCRIPTION
add `--toolbox-bgcolor-inactive` to fix unfocused window color. very small pr but fixes a certain annoyance