### PR TITLE
Reapply: fix: change track color for media controls in all themes

### DIFF
--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -11,7 +11,6 @@ whiskers:
 /* Catppuccin {{flavor.identifier | capitalize}} {{accent | capitalize}} userChrome.css*/
 
 @media (prefers-color-scheme: {{ if(cond=flavor.dark, t="dark", f="light") }}) {
-
   :root {
     --zen-colors-primary: #{{ surface0.hex }} !important;
     --zen-primary-color: #{{ palette[accent].hex }} !important;
@@ -70,9 +69,22 @@ whiskers:
     background: #{{ crust.hex }} !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #{{ surface0.hex }} !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #{{ crust.hex }};
       }
     }

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Blue userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #8caaee !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Flamingo userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #eebebe !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Green userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #a6d189 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Lavender userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #babbf1 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Maroon userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #ea999c !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Mauve userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #ca9ee6 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Peach userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #ef9f76 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Pink userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #f4b8e4 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Red userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #e78284 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Rosewater userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #f2d5cf !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Sapphire userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #85c1dc !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Sky userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #99d1db !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Teal userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #81c8be !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Frappe Yellow userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #414559 !important;
     --zen-primary-color: #e5c890 !important;
@@ -60,9 +59,22 @@
     background: #232634 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #414559 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #232634;
       }
     }

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Blue userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #1e66f5 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Flamingo userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #dd7878 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Green userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #40a02b !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Lavender userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #7287fd !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Maroon userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #e64553 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Mauve userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #8839ef !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Peach userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #fe640b !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Pink userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #ea76cb !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Red userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #d20f39 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Rosewater userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #dc8a78 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Sapphire userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #209fb5 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Sky userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #04a5e5 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Teal userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #179299 !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Latte Yellow userChrome.css*/
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --zen-colors-primary: #ccd0da !important;
     --zen-primary-color: #df8e1d !important;
@@ -60,9 +59,22 @@
     background: #dce0e8 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #ccd0da !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #dce0e8;
       }
     }

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Blue userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #8aadf4 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Flamingo userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #f0c6c6 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Green userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #a6da95 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Lavender userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #b7bdf8 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Maroon userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #ee99a0 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Mauve userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #c6a0f6 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Peach userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #f5a97f !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Pink userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #f5bde6 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Red userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #ed8796 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Rosewater userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #f4dbd6 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Sapphire userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #7dc4e4 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Sky userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #91d7e3 !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Teal userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #8bd5ca !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Macchiato Yellow userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #363a4f !important;
     --zen-primary-color: #eed49f !important;
@@ -60,9 +59,22 @@
     background: #181926 !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #363a4f !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #181926;
       }
     }

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Blue userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #89b4fa !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Flamingo userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #f2cdcd !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Green userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #a6e3a1 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Lavender userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #b4befe !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Maroon userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #eba0ac !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Mauve userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #cba6f7 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Peach userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #fab387 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Pink userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #f5c2e7 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Red userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #f38ba8 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Rosewater userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #f5e0dc !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Sapphire userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #74c7ec !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Sky userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #89dceb !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Teal userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #94e2d5 !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -1,7 +1,6 @@
 /* Catppuccin Mocha Yellow userChrome.css*/
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --zen-colors-primary: #313244 !important;
     --zen-primary-color: #f9e2af !important;
@@ -60,9 +59,22 @@
     background: #11111b !important;
   }
 
+  #zen-media-controls-toolbar {
+    & #zen-media-progress-bar {
+      &::-moz-range-track {
+        background: #313244 !important;
+      }
+    }
+  }
+
   toolbar .toolbarbutton-1 {
     &:not([disabled]) {
-      &:is([open], [checked]) > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack){
+      &:is([open], [checked])
+        > :is(
+          .toolbarbutton-icon,
+          .toolbarbutton-text,
+          .toolbarbutton-badge-stack
+        ) {
         fill: #11111b;
       }
     }


### PR DESCRIPTION
This fixes an issue where the color of the track and progress bar were the same, making it difficult to see the remaining playback time.

- Update userChrome.tera template
- Normalise formatting in userChrome.css

![fix-media-controls-track-color](https://github.com/user-attachments/assets/69c02e66-8ba3-4a20-a775-fbf725382f3d)

Original PR: #39