### PR TITLE
fix 🐛: Fix CSS for compact mode

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -3,7 +3,7 @@ name: whiskers
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [fix/compact-mode-css]
   pull_request:
     branches: [main]
 

--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -36,6 +36,14 @@ whiskers:
     --toolbox-bgcolor-inactive: #{{ mantle.hex }} !important;
   }
 
+  hbox#titlebar {
+    background-color: #{{ mantle.hex }} !important;
+  }
+
+  #zen-appcontent-navbar-container {
+    background-color: #{{ mantle.hex }} !important;
+  }
+
   #permissions-granted-icon{
     color: #{{ mantle.hex }} !important;
   }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -26,7 +26,23 @@
     --toolbox-bgcolor-inactive: #181825 !important;
   }
 
-  #permissions-granted-icon{
+  toolbar#nav-bar.browser-toolbar.chromeclass-location {
+    background-color: #181825 !important;
+  }
+
+  hbox#titlebar {
+    background-color: #181825 !important;
+  }
+
+  toolbartabstop {
+    background-color: #181825 !important;
+  }
+
+  #zen-appcontent-navbar-container {
+    background-color: #181825 !important;
+  }
+
+  #permissions-granted-icon {
     color: #181825 !important;
   }
 

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -26,18 +26,12 @@
     --toolbox-bgcolor-inactive: #181825 !important;
   }
 
-  toolbar#nav-bar.browser-toolbar.chromeclass-location {
-    background-color: #181825 !important;
-  }
-
+  /* For Vertical bar (Sidebar) */
   hbox#titlebar {
     background-color: #181825 !important;
   }
 
-  toolbartabstop {
-    background-color: #181825 !important;
-  }
-
+  /* For Toolbar  */
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }


### PR DESCRIPTION
There are few bugs where theme (for toolbar and corners at sidebar) doesn't apply for compact mode 

Before :
![toolbar](https://github.com/user-attachments/assets/739066ac-b051-4c06-a478-60f10e08bc7b)

After:

![After Toolbar](https://github.com/user-attachments/assets/5ba10f9d-c254-4be0-815d-53060573c680)

I did this for mocha's mauve color.. If this will accept I will add for other color as well.

And This change solved all types of compact mode issue with theme..