### PR TITLE
Fix/urlbar background

### DIFF
--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -52,7 +52,7 @@ whiskers:
     background-color: #{{ mantle.hex }} !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #{{ base.hex }} !important;
   }
 

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #292c3c !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #303446 !important;
   }
 

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #e6e9ef !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #eff1f5 !important;
   }
 

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #1e2030 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #24273a !important;
   }
 

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -42,7 +42,7 @@
     background-color: #181825 !important;
   }
 
-  #urlbar-background {
+  .urlbar-background {
     background-color: #1e1e2e !important;
   }
 


### PR DESCRIPTION
### Zen Catppuccin Theme (with URL Bar Fix)

After the latest Zen update, a bug was introduced where the background color was not being applied to the floating URL bar. This caused visual inconsistency in all Catppuccin themes.

This pull request fixes the issue by ensuring the background color is correctly applied to the floating URL bar across all Catppuccin variants, restoring the intended cohesive look.

To :
<img width="1194" height="709" alt="image" src="https://github.com/user-attachments/assets/c4227fe2-81c0-411b-bbae-4dff9a3f83b2" />

From : 
<img width="1194" height="732" alt="image" src="https://github.com/user-attachments/assets/c8c4a39f-6419-452b-b93e-82bc8dff5da1" />

Apologies for the screenshots. I couldn't take a proper screenshot because the floating bar closes whenever I try. So, I took a photo from my mobile.

Issue : https://github.com/catppuccin/zen-browser/pull/44#issuecomment-3335734269